### PR TITLE
Minor cleanups

### DIFF
--- a/Sources/TensorFlow/Core/KeyPathIterable.swift
+++ b/Sources/TensorFlow/Core/KeyPathIterable.swift
@@ -125,20 +125,7 @@ extension Array: KeyPathIterable {
   }
 }
 
-// TODO(TF-938): Remove this conformance after removing
-// `Element: Differentiable` requirement.
-//
-// Currently necessary to avoid error:
-//
-//   error: conditional conformance of type 'Array<Element>.DifferentiableView'
-//   to protocol 'KeyPathIterable' does not imply conformance to inherited
-//   protocol '_KeyPathIterableBase'.
-extension Array.DifferentiableView: _KeyPathIterableBase
-where Element: Differentiable {}
-
-// TODO(TF-938): Remove `Element: Differentiable` requirement.
-extension Array.DifferentiableView: KeyPathIterable
-where Element: Differentiable {
+extension Array.DifferentiableView: KeyPathIterable {
   public typealias AllKeyPaths = [PartialKeyPath<Array.DifferentiableView>]
   public var allKeyPaths: [PartialKeyPath<Array.DifferentiableView>] {
     return [\Array.DifferentiableView.base]

--- a/Sources/TensorFlow/Core/KeyPathIterable.swift
+++ b/Sources/TensorFlow/Core/KeyPathIterable.swift
@@ -125,7 +125,20 @@ extension Array: KeyPathIterable {
   }
 }
 
-extension Array.DifferentiableView: KeyPathIterable {
+// TODO(TF-938): Remove this conformance after removing
+// `Element: Differentiable` requirement.
+//
+// Currently necessary to avoid error:
+//
+//   error: conditional conformance of type 'Array<Element>.DifferentiableView'
+//   to protocol 'KeyPathIterable' does not imply conformance to inherited
+//   protocol '_KeyPathIterableBase'.
+extension Array.DifferentiableView: _KeyPathIterableBase
+where Element: Differentiable {}
+
+// TODO(TF-938): Remove `Element: Differentiable` requirement.
+extension Array.DifferentiableView: KeyPathIterable
+where Element: Differentiable {
   public typealias AllKeyPaths = [PartialKeyPath<Array.DifferentiableView>]
   public var allKeyPaths: [PartialKeyPath<Array.DifferentiableView>] {
     return [\Array.DifferentiableView.base]

--- a/Sources/TensorFlow/Epochs/Algorithms.swift
+++ b/Sources/TensorFlow/Epochs/Algorithms.swift
@@ -592,7 +592,7 @@ extension Collection {
 }
 
 extension LazyCollectionProtocol
-where Element == Elements.Element, Elements: Collection {
+where Element == Elements.Element {
   func stablyPartitioned(
     isSuffixElement p: (Element) -> Bool
   ) -> LazyCollection<[Element]> {

--- a/Sources/TensorFlow/Layer.swift
+++ b/Sources/TensorFlow/Layer.swift
@@ -203,11 +203,12 @@ extension Layer {
   ///
   /// - Parameter input: The input to the layer.
   /// - Returns: The inference output.
+  @differentiable(reverse)
   public func inferring(from input: Input) -> Output {
     withLearningPhase(LearningPhase.inference) { self(input) }
   }
 
-  // TODO(TF-433, SR-11882): Remove this custom derivative when
+  // TODO(SR-11882): Remove this custom derivative when
   // differentiation supports `rethrows` functions and currying.
   @usableFromInline
   @derivative(of: inferring(from:))

--- a/Sources/TensorFlow/Layers/Dense.swift
+++ b/Sources/TensorFlow/Layers/Dense.swift
@@ -61,18 +61,6 @@ public struct Dense<Scalar: TensorFlowFloatingPoint>: Layer {
     useBias = (bias != nil)
   }
 
-  // TODO(TF-433): Remove custom derivative after `try_apply` differentiation is supported.
-  @derivative(of: init, wrt: weight)
-  @usableFromInline
-  static func vjpInit(
-    weight: Tensor<Scalar>,
-    bias: Tensor<Scalar>? = nil,
-    activation: @escaping Activation
-  ) -> (value: Self, pullback: (TangentVector) -> Tensor<Scalar>) {
-    let value = Dense(weight: weight, bias: bias, activation: activation)
-    return (value, { v in v.weight })
-  }
-
   /// Returns the output obtained from applying the layer to the given input.
   ///
   /// - Parameter input: The input to the layer.

--- a/Sources/TensorFlow/Layers/Dropout.swift
+++ b/Sources/TensorFlow/Layers/Dropout.swift
@@ -20,7 +20,7 @@ import _Differentiation
 
 extension Tensor where Scalar: TensorFlowFloatingPoint {
   /// Computes dropout given a probability.
-  @differentiable(reverse, wrt: self where Scalar: Differentiable)
+  @differentiable(reverse, wrt: self)
   fileprivate func droppingOut(probability: Double) -> Tensor {
     let noise = Tensor(randomUniform: shape, on: device)
     let keepMask = noise .>= Scalar(probability)

--- a/Sources/TensorFlow/Operators/Basic.swift
+++ b/Sources/TensorFlow/Operators/Basic.swift
@@ -576,9 +576,10 @@ extension Tensor {
     // non-batch dimension, recursively calling `batchGathering` with `axis = 0`, and then
     // transposing the result to put the pre-axis dimensions before the indices dimensions.
     if axis != batchDimensionCount {
-      // TODO: precondition(axis >= 0 && axis < rank, "'axis' is out of range.")
-      // TODO: precondition(batchDimensionCount <= axis,
-      //                    "'batchDimensionCount' must be less than or equal to 'axis'.")
+       precondition(axis >= 0 && axis < rank, "'axis' is out of range.")
+       precondition(
+         batchDimensionCount <= axis,
+         "'batchDimensionCount' must be less than or equal to 'axis'.")
 
       // Move self[axis] up to self[batchDimensionCount].
       let permutation = Tensor<Int32>(concatenating: [

--- a/Sources/TensorFlow/Optimizers/MomentumBased.swift
+++ b/Sources/TensorFlow/Optimizers/MomentumBased.swift
@@ -33,8 +33,7 @@ import Numerics
 public class RMSProp<Model: Differentiable>: Optimizer
 where
   Model.TangentVector: VectorProtocol & PointwiseMultiplicative
-    & ElementaryFunctions & KeyPathIterable_SR15884_Workaround,
-  Model.TangentVector.VectorSpaceScalar == Float
+    & ElementaryFunctions & KeyPathIterable_SR15884_Workaround
 {
   public typealias Model = Model
   /// The learning rate.
@@ -110,8 +109,7 @@ where
 public class AdaGrad<Model: Differentiable>: Optimizer
 where
   Model.TangentVector: VectorProtocol & PointwiseMultiplicative
-    & ElementaryFunctions & KeyPathIterable_SR15884_Workaround,
-  Model.TangentVector.VectorSpaceScalar == Float
+    & ElementaryFunctions & KeyPathIterable_SR15884_Workaround
 {
   public typealias Model = Model
   /// The learning rate.
@@ -173,8 +171,7 @@ where
 public class AdaDelta<Model: Differentiable>: Optimizer
 where
   Model.TangentVector: VectorProtocol & PointwiseMultiplicative
-    & ElementaryFunctions & KeyPathIterable_SR15884_Workaround,
-  Model.TangentVector.VectorSpaceScalar == Float
+    & ElementaryFunctions & KeyPathIterable_SR15884_Workaround
 {
   public typealias Model = Model
   /// The learning rate.
@@ -325,8 +322,7 @@ where
 public class Adam<Model: Differentiable>: Optimizer
 where
   Model.TangentVector: VectorProtocol & PointwiseMultiplicative
-    & ElementaryFunctions & KeyPathIterable_SR15884_Workaround,
-  Model.TangentVector.VectorSpaceScalar == Float
+    & ElementaryFunctions & KeyPathIterable_SR15884_Workaround
 {
   public typealias Model = Model
   /// The learning rate.
@@ -412,8 +408,7 @@ where
 public class AdaMax<Model: Differentiable & KeyPathIterable>: Optimizer
 where
   Model.TangentVector: VectorProtocol & PointwiseMultiplicative
-    & ElementaryFunctions & KeyPathIterable_SR15884_Workaround,
-  Model.TangentVector.VectorSpaceScalar == Float
+    & ElementaryFunctions & KeyPathIterable_SR15884_Workaround
 {
   public typealias Model = Model
   /// The learning rate.
@@ -500,8 +495,7 @@ where
 public class AMSGrad<Model: Differentiable & KeyPathIterable>: Optimizer
 where
   Model.TangentVector: VectorProtocol & PointwiseMultiplicative
-    & ElementaryFunctions & KeyPathIterable_SR15884_Workaround,
-  Model.TangentVector.VectorSpaceScalar == Float
+    & ElementaryFunctions & KeyPathIterable_SR15884_Workaround
 {
   public typealias Model = Model
   /// The learning rate.
@@ -594,8 +588,7 @@ where
 public class RAdam<Model: Differentiable>: Optimizer
 where
   Model.TangentVector: VectorProtocol & PointwiseMultiplicative
-    & ElementaryFunctions & KeyPathIterable_SR15884_Workaround,
-  Model.TangentVector.VectorSpaceScalar == Float
+    & ElementaryFunctions & KeyPathIterable_SR15884_Workaround
 {
   public typealias Model = Model
   /// The learning rate.

--- a/Sources/TensorFlow/Optimizers/SGD.swift
+++ b/Sources/TensorFlow/Optimizers/SGD.swift
@@ -39,8 +39,7 @@ import Numerics
 public class SGD<Model: Differentiable>: Optimizer
 where
   Model.TangentVector: VectorProtocol & ElementaryFunctions
-    & KeyPathIterable_SR15884_Workaround,
-  Model.TangentVector.VectorSpaceScalar == Float
+    & KeyPathIterable_SR15884_Workaround
 {
   public typealias Model = Model
   /// The learning rate.

--- a/Sources/x10/swift_bindings/optimizers/Optimizer.swift
+++ b/Sources/x10/swift_bindings/optimizers/Optimizer.swift
@@ -118,8 +118,7 @@ public struct ParameterGroupOptimizer {
 /// This is for efficiency to prevent multiple inefficient iterations over the gradient.
 public class GeneralOptimizer<Model: EuclideanDifferentiable>: Optimizer
 where
-  Model.TangentVector: VectorProtocol & ElementaryFunctions & KeyPathIterable,
-  Model.TangentVector.VectorSpaceScalar == Float
+  Model.TangentVector: VectorProtocol & ElementaryFunctions & KeyPathIterable
 {
   public typealias Model = Model
   /// The set of steps taken.

--- a/Tests/TensorFlowTests/SequencedTests.swift
+++ b/Tests/TensorFlowTests/SequencedTests.swift
@@ -1,4 +1,4 @@
-// ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 1)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 1)
 // Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,18 +13,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 16)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 16)
 
-import TensorFlow
 import XCTest
+import TensorFlow
 
-// ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 21)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 21)
 struct Model2: Layer {
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 23)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 23)
   var multiply1: Multiply = Multiply(coefficient: 1)
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 23)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 23)
   var multiply2: Multiply = Multiply(coefficient: 2)
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 25)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 25)
 
   @differentiable(reverse)
   func callAsFunction(_ input: Float) -> Float {
@@ -33,15 +33,15 @@ struct Model2: Layer {
     )
   }
 }
-// ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 21)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 21)
 struct Model3: Layer {
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 23)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 23)
   var multiply1: Multiply = Multiply(coefficient: 1)
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 23)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 23)
   var multiply2: Multiply = Multiply(coefficient: 2)
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 23)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 23)
   var multiply3: Multiply = Multiply(coefficient: 3)
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 25)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 25)
 
   @differentiable(reverse)
   func callAsFunction(_ input: Float) -> Float {
@@ -50,17 +50,17 @@ struct Model3: Layer {
     )
   }
 }
-// ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 21)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 21)
 struct Model4: Layer {
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 23)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 23)
   var multiply1: Multiply = Multiply(coefficient: 1)
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 23)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 23)
   var multiply2: Multiply = Multiply(coefficient: 2)
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 23)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 23)
   var multiply3: Multiply = Multiply(coefficient: 3)
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 23)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 23)
   var multiply4: Multiply = Multiply(coefficient: 4)
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 25)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 25)
 
   @differentiable(reverse)
   func callAsFunction(_ input: Float) -> Float {
@@ -69,19 +69,19 @@ struct Model4: Layer {
     )
   }
 }
-// ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 21)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 21)
 struct Model5: Layer {
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 23)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 23)
   var multiply1: Multiply = Multiply(coefficient: 1)
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 23)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 23)
   var multiply2: Multiply = Multiply(coefficient: 2)
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 23)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 23)
   var multiply3: Multiply = Multiply(coefficient: 3)
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 23)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 23)
   var multiply4: Multiply = Multiply(coefficient: 4)
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 23)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 23)
   var multiply5: Multiply = Multiply(coefficient: 5)
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 25)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 25)
 
   @differentiable(reverse)
   func callAsFunction(_ input: Float) -> Float {
@@ -90,21 +90,21 @@ struct Model5: Layer {
     )
   }
 }
-// ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 21)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 21)
 struct Model6: Layer {
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 23)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 23)
   var multiply1: Multiply = Multiply(coefficient: 1)
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 23)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 23)
   var multiply2: Multiply = Multiply(coefficient: 2)
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 23)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 23)
   var multiply3: Multiply = Multiply(coefficient: 3)
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 23)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 23)
   var multiply4: Multiply = Multiply(coefficient: 4)
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 23)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 23)
   var multiply5: Multiply = Multiply(coefficient: 5)
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 23)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 23)
   var multiply6: Multiply = Multiply(coefficient: 6)
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 25)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 25)
 
   @differentiable(reverse)
   func callAsFunction(_ input: Float) -> Float {
@@ -113,10 +113,10 @@ struct Model6: Layer {
     )
   }
 }
-// ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 34)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 34)
 
 final class SequencedTests: XCTestCase {
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 37)
   func testSequenced2() {
     let input = Float(1)
     let model = Model2()
@@ -126,13 +126,13 @@ final class SequencedTests: XCTestCase {
 
     XCTAssertEqual(Float(factorial(2)), output)
     XCTAssertEqual(Float(factorial(2)), gInput)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 47)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 47)
     XCTAssertEqual(Float(factorial(2) / 1), gModel.multiply1.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 47)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 47)
     XCTAssertEqual(Float(factorial(2) / 2), gModel.multiply2.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 49)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 49)
   }
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 37)
   func testSequenced3() {
     let input = Float(1)
     let model = Model3()
@@ -142,15 +142,15 @@ final class SequencedTests: XCTestCase {
 
     XCTAssertEqual(Float(factorial(3)), output)
     XCTAssertEqual(Float(factorial(3)), gInput)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 47)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 47)
     XCTAssertEqual(Float(factorial(3) / 1), gModel.multiply1.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 47)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 47)
     XCTAssertEqual(Float(factorial(3) / 2), gModel.multiply2.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 47)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 47)
     XCTAssertEqual(Float(factorial(3) / 3), gModel.multiply3.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 49)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 49)
   }
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 37)
   func testSequenced4() {
     let input = Float(1)
     let model = Model4()
@@ -160,17 +160,17 @@ final class SequencedTests: XCTestCase {
 
     XCTAssertEqual(Float(factorial(4)), output)
     XCTAssertEqual(Float(factorial(4)), gInput)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 47)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 47)
     XCTAssertEqual(Float(factorial(4) / 1), gModel.multiply1.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 47)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 47)
     XCTAssertEqual(Float(factorial(4) / 2), gModel.multiply2.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 47)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 47)
     XCTAssertEqual(Float(factorial(4) / 3), gModel.multiply3.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 47)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 47)
     XCTAssertEqual(Float(factorial(4) / 4), gModel.multiply4.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 49)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 49)
   }
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 37)
   func testSequenced5() {
     let input = Float(1)
     let model = Model5()
@@ -180,19 +180,19 @@ final class SequencedTests: XCTestCase {
 
     XCTAssertEqual(Float(factorial(5)), output)
     XCTAssertEqual(Float(factorial(5)), gInput)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 47)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 47)
     XCTAssertEqual(Float(factorial(5) / 1), gModel.multiply1.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 47)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 47)
     XCTAssertEqual(Float(factorial(5) / 2), gModel.multiply2.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 47)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 47)
     XCTAssertEqual(Float(factorial(5) / 3), gModel.multiply3.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 47)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 47)
     XCTAssertEqual(Float(factorial(5) / 4), gModel.multiply4.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 47)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 47)
     XCTAssertEqual(Float(factorial(5) / 5), gModel.multiply5.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 49)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 49)
   }
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 37)
   func testSequenced6() {
     let input = Float(1)
     let model = Model6()
@@ -202,33 +202,33 @@ final class SequencedTests: XCTestCase {
 
     XCTAssertEqual(Float(factorial(6)), output)
     XCTAssertEqual(Float(factorial(6)), gInput)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 47)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 47)
     XCTAssertEqual(Float(factorial(6) / 1), gModel.multiply1.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 47)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 47)
     XCTAssertEqual(Float(factorial(6) / 2), gModel.multiply2.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 47)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 47)
     XCTAssertEqual(Float(factorial(6) / 3), gModel.multiply3.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 47)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 47)
     XCTAssertEqual(Float(factorial(6) / 4), gModel.multiply4.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 47)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 47)
     XCTAssertEqual(Float(factorial(6) / 5), gModel.multiply5.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 47)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 47)
     XCTAssertEqual(Float(factorial(6) / 6), gModel.multiply6.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 49)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 49)
   }
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 51)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 51)
 
   static var allTests = [
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 54)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 54)
     ("testSequenced2", testSequenced2),
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 54)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 54)
     ("testSequenced3", testSequenced3),
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 54)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 54)
     ("testSequenced4", testSequenced4),
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 54)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 54)
     ("testSequenced5", testSequenced5),
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 54)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 54)
     ("testSequenced6", testSequenced6),
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequencedTests.swift.gyb", line: 56)
+// ###sourceLocation(file: "SequencedTests.swift.gyb", line: 56)
   ]
 }

--- a/Tests/TensorFlowTests/SequentialTests.swift
+++ b/Tests/TensorFlowTests/SequentialTests.swift
@@ -1,4 +1,4 @@
-// ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 1)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 1)
 // Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,22 +13,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 16)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 16)
 
-import TensorFlow
 import XCTest
+import TensorFlow
 
 final class SequentialTests: XCTestCase {
 #if !SR15884_WORKAROUND_1
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 22)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 23)
   func testSequential2() {
     let input = Float(1)
     let model = Sequential {
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 1)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 2)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 28)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 29)
     }
 
     let (output, (gInput, gModel)) = valueWithGradient(at: input, model) {
@@ -37,25 +37,25 @@ final class SequentialTests: XCTestCase {
 
     XCTAssertEqual(Float(factorial(2)), output)
     XCTAssertEqual(Float(factorial(2)), gInput)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel1 = gModel.layer1
     XCTAssertEqual(Float(factorial(2) / 1), gModel1.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel2 = gModel.layer2
     XCTAssertEqual(Float(factorial(2) / 2), gModel2.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 40)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 41)
   }
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 22)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 23)
   func testSequential3() {
     let input = Float(1)
     let model = Sequential {
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 1)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 2)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 3)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 28)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 29)
     }
 
     let (output, (gInput, gModel)) = valueWithGradient(at: input, model) {
@@ -64,30 +64,30 @@ final class SequentialTests: XCTestCase {
 
     XCTAssertEqual(Float(factorial(3)), output)
     XCTAssertEqual(Float(factorial(3)), gInput)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel1 = gModel.layer1
     XCTAssertEqual(Float(factorial(3) / 1), gModel1.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel2 = gModel.layer2.layer1
     XCTAssertEqual(Float(factorial(3) / 2), gModel2.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel3 = gModel.layer2.layer2
     XCTAssertEqual(Float(factorial(3) / 3), gModel3.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 40)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 41)
   }
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 22)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 23)
   func testSequential4() {
     let input = Float(1)
     let model = Sequential {
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 1)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 2)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 3)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 4)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 28)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 29)
     }
 
     let (output, (gInput, gModel)) = valueWithGradient(at: input, model) {
@@ -96,35 +96,35 @@ final class SequentialTests: XCTestCase {
 
     XCTAssertEqual(Float(factorial(4)), output)
     XCTAssertEqual(Float(factorial(4)), gInput)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel1 = gModel.layer1
     XCTAssertEqual(Float(factorial(4) / 1), gModel1.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel2 = gModel.layer2.layer1
     XCTAssertEqual(Float(factorial(4) / 2), gModel2.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel3 = gModel.layer2.layer2.layer1
     XCTAssertEqual(Float(factorial(4) / 3), gModel3.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel4 = gModel.layer2.layer2.layer2
     XCTAssertEqual(Float(factorial(4) / 4), gModel4.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 40)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 41)
   }
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 22)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 23)
   func testSequential5() {
     let input = Float(1)
     let model = Sequential {
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 1)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 2)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 3)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 4)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 5)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 28)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 29)
     }
 
     let (output, (gInput, gModel)) = valueWithGradient(at: input, model) {
@@ -133,40 +133,40 @@ final class SequentialTests: XCTestCase {
 
     XCTAssertEqual(Float(factorial(5)), output)
     XCTAssertEqual(Float(factorial(5)), gInput)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel1 = gModel.layer1
     XCTAssertEqual(Float(factorial(5) / 1), gModel1.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel2 = gModel.layer2.layer1
     XCTAssertEqual(Float(factorial(5) / 2), gModel2.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel3 = gModel.layer2.layer2.layer1
     XCTAssertEqual(Float(factorial(5) / 3), gModel3.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel4 = gModel.layer2.layer2.layer2.layer1
     XCTAssertEqual(Float(factorial(5) / 4), gModel4.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel5 = gModel.layer2.layer2.layer2.layer2
     XCTAssertEqual(Float(factorial(5) / 5), gModel5.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 40)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 41)
   }
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 22)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 23)
   func testSequential6() {
     let input = Float(1)
     let model = Sequential {
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 1)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 2)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 3)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 4)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 5)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 6)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 28)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 29)
     }
 
     let (output, (gInput, gModel)) = valueWithGradient(at: input, model) {
@@ -175,45 +175,45 @@ final class SequentialTests: XCTestCase {
 
     XCTAssertEqual(Float(factorial(6)), output)
     XCTAssertEqual(Float(factorial(6)), gInput)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel1 = gModel.layer1
     XCTAssertEqual(Float(factorial(6) / 1), gModel1.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel2 = gModel.layer2.layer1
     XCTAssertEqual(Float(factorial(6) / 2), gModel2.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel3 = gModel.layer2.layer2.layer1
     XCTAssertEqual(Float(factorial(6) / 3), gModel3.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel4 = gModel.layer2.layer2.layer2.layer1
     XCTAssertEqual(Float(factorial(6) / 4), gModel4.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel5 = gModel.layer2.layer2.layer2.layer2.layer1
     XCTAssertEqual(Float(factorial(6) / 5), gModel5.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel6 = gModel.layer2.layer2.layer2.layer2.layer2
     XCTAssertEqual(Float(factorial(6) / 6), gModel6.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 40)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 41)
   }
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 22)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 23)
   func testSequential7() {
     let input = Float(1)
     let model = Sequential {
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 1)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 2)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 3)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 4)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 5)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 6)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 7)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 28)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 29)
     }
 
     let (output, (gInput, gModel)) = valueWithGradient(at: input, model) {
@@ -222,50 +222,50 @@ final class SequentialTests: XCTestCase {
 
     XCTAssertEqual(Float(factorial(7)), output)
     XCTAssertEqual(Float(factorial(7)), gInput)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel1 = gModel.layer1
     XCTAssertEqual(Float(factorial(7) / 1), gModel1.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel2 = gModel.layer2.layer1
     XCTAssertEqual(Float(factorial(7) / 2), gModel2.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel3 = gModel.layer2.layer2.layer1
     XCTAssertEqual(Float(factorial(7) / 3), gModel3.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel4 = gModel.layer2.layer2.layer2.layer1
     XCTAssertEqual(Float(factorial(7) / 4), gModel4.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel5 = gModel.layer2.layer2.layer2.layer2.layer1
     XCTAssertEqual(Float(factorial(7) / 5), gModel5.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel6 = gModel.layer2.layer2.layer2.layer2.layer2.layer1
     XCTAssertEqual(Float(factorial(7) / 6), gModel6.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel7 = gModel.layer2.layer2.layer2.layer2.layer2.layer2
     XCTAssertEqual(Float(factorial(7) / 7), gModel7.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 40)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 41)
   }
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 22)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 23)
   func testSequential8() {
     let input = Float(1)
     let model = Sequential {
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 1)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 2)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 3)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 4)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 5)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 6)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 7)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 8)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 28)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 29)
     }
 
     let (output, (gInput, gModel)) = valueWithGradient(at: input, model) {
@@ -274,55 +274,55 @@ final class SequentialTests: XCTestCase {
 
     XCTAssertEqual(Float(factorial(8)), output)
     XCTAssertEqual(Float(factorial(8)), gInput)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel1 = gModel.layer1
     XCTAssertEqual(Float(factorial(8) / 1), gModel1.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel2 = gModel.layer2.layer1
     XCTAssertEqual(Float(factorial(8) / 2), gModel2.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel3 = gModel.layer2.layer2.layer1
     XCTAssertEqual(Float(factorial(8) / 3), gModel3.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel4 = gModel.layer2.layer2.layer2.layer1
     XCTAssertEqual(Float(factorial(8) / 4), gModel4.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel5 = gModel.layer2.layer2.layer2.layer2.layer1
     XCTAssertEqual(Float(factorial(8) / 5), gModel5.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel6 = gModel.layer2.layer2.layer2.layer2.layer2.layer1
     XCTAssertEqual(Float(factorial(8) / 6), gModel6.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel7 = gModel.layer2.layer2.layer2.layer2.layer2.layer2.layer1
     XCTAssertEqual(Float(factorial(8) / 7), gModel7.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel8 = gModel.layer2.layer2.layer2.layer2.layer2.layer2.layer2
     XCTAssertEqual(Float(factorial(8) / 8), gModel8.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 40)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 41)
   }
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 22)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 23)
   func testSequential9() {
     let input = Float(1)
     let model = Sequential {
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 1)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 2)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 3)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 4)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 5)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 6)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 7)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 8)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 9)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 28)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 29)
     }
 
     let (output, (gInput, gModel)) = valueWithGradient(at: input, model) {
@@ -331,60 +331,60 @@ final class SequentialTests: XCTestCase {
 
     XCTAssertEqual(Float(factorial(9)), output)
     XCTAssertEqual(Float(factorial(9)), gInput)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel1 = gModel.layer1
     XCTAssertEqual(Float(factorial(9) / 1), gModel1.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel2 = gModel.layer2.layer1
     XCTAssertEqual(Float(factorial(9) / 2), gModel2.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel3 = gModel.layer2.layer2.layer1
     XCTAssertEqual(Float(factorial(9) / 3), gModel3.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel4 = gModel.layer2.layer2.layer2.layer1
     XCTAssertEqual(Float(factorial(9) / 4), gModel4.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel5 = gModel.layer2.layer2.layer2.layer2.layer1
     XCTAssertEqual(Float(factorial(9) / 5), gModel5.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel6 = gModel.layer2.layer2.layer2.layer2.layer2.layer1
     XCTAssertEqual(Float(factorial(9) / 6), gModel6.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel7 = gModel.layer2.layer2.layer2.layer2.layer2.layer2.layer1
     XCTAssertEqual(Float(factorial(9) / 7), gModel7.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel8 = gModel.layer2.layer2.layer2.layer2.layer2.layer2.layer2.layer1
     XCTAssertEqual(Float(factorial(9) / 8), gModel8.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel9 = gModel.layer2.layer2.layer2.layer2.layer2.layer2.layer2.layer2
     XCTAssertEqual(Float(factorial(9) / 9), gModel9.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 40)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 41)
   }
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 22)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 23)
   func testSequential10() {
     let input = Float(1)
     let model = Sequential {
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 1)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 2)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 3)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 4)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 5)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 6)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 7)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 8)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 9)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 26)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 27)
       Multiply(coefficient: 10)
-      // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 28)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 29)
     }
 
     let (output, (gInput, gModel)) = valueWithGradient(at: input, model) {
@@ -393,60 +393,60 @@ final class SequentialTests: XCTestCase {
 
     XCTAssertEqual(Float(factorial(10)), output)
     XCTAssertEqual(Float(factorial(10)), gInput)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel1 = gModel.layer1
     XCTAssertEqual(Float(factorial(10) / 1), gModel1.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel2 = gModel.layer2.layer1
     XCTAssertEqual(Float(factorial(10) / 2), gModel2.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel3 = gModel.layer2.layer2.layer1
     XCTAssertEqual(Float(factorial(10) / 3), gModel3.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel4 = gModel.layer2.layer2.layer2.layer1
     XCTAssertEqual(Float(factorial(10) / 4), gModel4.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel5 = gModel.layer2.layer2.layer2.layer2.layer1
     XCTAssertEqual(Float(factorial(10) / 5), gModel5.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel6 = gModel.layer2.layer2.layer2.layer2.layer2.layer1
     XCTAssertEqual(Float(factorial(10) / 6), gModel6.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel7 = gModel.layer2.layer2.layer2.layer2.layer2.layer2.layer1
     XCTAssertEqual(Float(factorial(10) / 7), gModel7.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel8 = gModel.layer2.layer2.layer2.layer2.layer2.layer2.layer2.layer1
     XCTAssertEqual(Float(factorial(10) / 8), gModel8.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel9 = gModel.layer2.layer2.layer2.layer2.layer2.layer2.layer2.layer2.layer1
     XCTAssertEqual(Float(factorial(10) / 9), gModel9.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 37)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 38)
     let gModel10 = gModel.layer2.layer2.layer2.layer2.layer2.layer2.layer2.layer2.layer2
     XCTAssertEqual(Float(factorial(10) / 10), gModel10.coefficient)
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 40)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 41)
   }
-  // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 42)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 43)
 
   static var allTests = [
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 45)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 46)
     ("testSequential2", testSequential2),
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 45)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 46)
     ("testSequential3", testSequential3),
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 45)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 46)
     ("testSequential4", testSequential4),
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 45)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 46)
     ("testSequential5", testSequential5),
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 45)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 46)
     ("testSequential6", testSequential6),
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 45)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 46)
     ("testSequential7", testSequential7),
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 45)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 46)
     ("testSequential8", testSequential8),
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 45)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 46)
     ("testSequential9", testSequential9),
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 45)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 46)
     ("testSequential10", testSequential10),
-    // ###sourceLocation(file: "/usr/local/google/home/marcrasi/git/swift-apis/Tests/TensorFlowTests/SequentialTests.swift.gyb", line: 47)
+// ###sourceLocation(file: "SequentialTests.swift.gyb", line: 48)
   ]
 #else
   func emptyTest() {}


### PR DESCRIPTION
Added the following minor cleanups to the code base:
- Removed workaround for TF-433: Support `try_apply` differentiation. This was fixed according to: https://github.com/tensorflow/swift-apis/pull/1069.
- Modified `SequencedTests.swift` and `SequentialTests.swift` to use only the source file names in line directives

Suppressed existing compiler warnings:
- Removed multiple instances of the redundant generic requirement `Model.TangentVector.VectorSpaceScalar == Float`
- Removed the redundant generic requirement `Elements: Collection` in `Epochs/Algorithms.swift`
- Removed the redundant generic requirement `Scalar: Differentiable` to the declaration of `Tensor.droppingOut(probability:)`


The TF-938 workaround is no longer necessary, according to: https://github.com/apple/swift/pull/41030. However, the workaround remains to preserve compatibility with older toolchains.